### PR TITLE
Use Gregorian calendar to avoid portfolio start year parsing issue

### DIFF
--- a/Shared/Models/Portfolio/Portfolio.swift
+++ b/Shared/Models/Portfolio/Portfolio.swift
@@ -80,6 +80,7 @@ extension Portfolio {
 
     static let monthFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MMMM yyyy"
         formatter.timeZone = .utc
         return formatter

--- a/Shared/Models/Portfolio/PortfolioConfig.swift
+++ b/Shared/Models/Portfolio/PortfolioConfig.swift
@@ -21,7 +21,7 @@ struct PortfolioConfig {
     }
 
     static var currentYear: Int {
-        Calendar.current.dateComponents([.year], from: Date()).year!
+        Calendar(identifier: .gregorian).dateComponents([.year], from: Date()).year!
     }
 
     static var defaultYear: Int {

--- a/Shared/Models/Record.swift
+++ b/Shared/Models/Record.swift
@@ -63,6 +63,7 @@ extension Record {
 
     static let monthFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MMMM yyyy"
         formatter.timeZone = .utc
         return formatter
@@ -70,6 +71,7 @@ extension Record {
 
     static let closeDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MM/dd/yyyy"
         formatter.timeZone = .utc
         return formatter

--- a/macOS/Views/PortfolioView/GrowthChart.swift
+++ b/macOS/Views/PortfolioView/GrowthChart.swift
@@ -48,6 +48,7 @@ extension GrowthChart {
 
         static var formatter: DateFormatter = {
             let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .gregorian)
             formatter.dateFormat = "MM/yyyy"
             formatter.timeZone = .utc
             return formatter

--- a/macOS/Views/PortfolioView/PortfolioReturnView.swift
+++ b/macOS/Views/PortfolioView/PortfolioReturnView.swift
@@ -118,6 +118,7 @@ private extension PortfolioReturnView {
 
     static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "MM/dd/yyyy"
         formatter.timeZone = .utc
         return formatter


### PR DESCRIPTION
This would ideally solve the problem of #66.